### PR TITLE
Fix KeyedPersistentDataType cross-plugin API

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/KeyedPersistentDataType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/datatypes/KeyedPersistentDataType.kt
@@ -4,6 +4,7 @@ import org.bukkit.Keyed
 import org.bukkit.NamespacedKey
 import org.bukkit.persistence.PersistentDataAdapterContext
 import org.bukkit.persistence.PersistentDataType
+import java.util.function.Function
 
 /**
  * A [PersistentDataType] that can be used with any class that implements [Keyed].
@@ -35,13 +36,35 @@ abstract class KeyedPersistentDataType<T : Keyed>(val type: Class<T>) : Persiste
     abstract fun retrieve(key: NamespacedKey): T
 
     companion object {
+        /**
+         * Kotlin-source compatibility overload.
+         *
+         * This method intentionally remains in the JVM ABI for already compiled Kotlin addons, but
+         * is hidden from Java source so Java plugins do not put kotlin.jvm.functions.Function1 in
+         * their cross-plugin call signature.
+         */
         @JvmStatic
+        @JvmSynthetic
         fun <T : Keyed> keyedTypeFrom(
             type: Class<T>,
             retrievalFunction: (NamespacedKey) -> T
         ): PersistentDataType<String, T> {
             return object : KeyedPersistentDataType<T>(type) {
                 override fun retrieve(key: NamespacedKey): T = retrievalFunction(key)
+            }
+        }
+
+        /**
+         * Java-safe overload. java.util.function.Function is loaded by the JVM/platform classloader,
+         * so it is safe to use in an API call crossing the Rebar/Pylon plugin-classloader boundary.
+         */
+        @JvmStatic
+        fun <T : Keyed> keyedTypeFrom(
+            type: Class<T>,
+            retrievalFunction: Function<NamespacedKey, T>
+        ): PersistentDataType<String, T> {
+            return object : KeyedPersistentDataType<T>(type) {
+                override fun retrieve(key: NamespacedKey): T = retrievalFunction.apply(key)
             }
         }
 


### PR DESCRIPTION
Adds a Java Function<NamespacedKey, T> overload for KeyedPersistentDataType.keyedTypeFrom.

I encountered a LinkageError when Pylon and Rebar were loaded through separate plugin classloaders. The existing public overload exposes Kotlin's Function1 in the cross-plugin method signature.

The Java Function overload avoids putting a Kotlin runtime type in that API boundary while retaining the existing Kotlin overload for source compatibility.