### PR TITLE
Harden startup and version handling

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/Rebar.kt
@@ -45,7 +45,6 @@ import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.util.mergeResource
 import io.github.pylonmc.rebar.waila.Waila
 import io.github.pylonmc.rebar.integration.WailaPlaceholders
-import io.papermc.paper.ServerBuildInfo
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -76,27 +75,33 @@ object Rebar : JavaPlugin(), RebarAddon {
     /**
      * Ticks once per tick
      */
+    private val mainThreadDispatcherDelegate = lazy { BukkitMainThreadDispatcher(this, 1) }
+
     @get:JvmSynthetic
     @get:ApiStatus.Internal
-    val mainThreadDispatcher by lazy { BukkitMainThreadDispatcher(this, 1) }
+    val mainThreadDispatcher
+        get() = mainThreadDispatcherDelegate.value
 
     /**
      * By default, dispatches on the main thread
      */
+    private val scopeDelegate = lazy { CoroutineScope(SupervisorJob() + mainThreadDispatcher) }
+
     @get:JvmSynthetic
     @get:ApiStatus.Internal
-    val scope by lazy { CoroutineScope(SupervisorJob() + mainThreadDispatcher) }
+    val scope
+        get() = scopeDelegate.value
+
+    private var metricsInitialized = false
 
     override fun onEnable() {
         val start = System.currentTimeMillis()
 
-        val expectedVersion = pluginMeta.apiVersion
-        val actualVersion = ServerBuildInfo.buildInfo().minecraftVersionId()
-
-        val expectedVersionParts = (expectedVersion ?: "").split(".").mapNotNull { it.toIntOrNull() }.dropLastWhile { it == 0 }
-        val actualVersionParts = actualVersion.split(".").mapNotNull { it.toIntOrNull() }.dropLastWhile { it == 0 }
-
-        if (expectedVersionParts != actualVersionParts) {
+        val expectedVersion = checkNotNull(pluginMeta.apiVersion) {
+            "Rebar plugin metadata is missing api-version; cannot verify Minecraft compatibility"
+        }
+        val actualVersion = Bukkit.getMinecraftVersion()
+        if (!minecraftVersionsMatch(actualVersion, expectedVersion)) {
             logger.severe("!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!")
             logger.severe("You are running Rebar on Minecraft version $actualVersion")
             logger.severe("This build of Rebar expects Minecraft version $expectedVersion")
@@ -125,6 +130,7 @@ object Rebar : JavaPlugin(), RebarAddon {
         pm.registerEvents(RebarAddon, this)
 
         RebarMetrics // initialize metrics by referencing it
+        metricsInitialized = true
 
         // Anything that listens for addon registration must be above this line
         registerWithRebar()
@@ -409,9 +415,14 @@ object Rebar : JavaPlugin(), RebarAddon {
     }
 
     override fun onDisable() {
-        // Note: At this point all listeners have been unregistered
-        RebarMetrics.save()
-        scope.cancel()
+        // Note: At this point all listeners have been unregistered. Avoid initializing
+        // subsystems here when onEnable failed early (for example, on a version mismatch).
+        if (metricsInitialized) {
+            RebarMetrics.save()
+        }
+        if (scopeDelegate.isInitialized()) {
+            scope.cancel()
+        }
     }
 
     override val javaPlugin = this
@@ -419,6 +430,30 @@ object Rebar : JavaPlugin(), RebarAddon {
     override val material = Material.BEDROCK
 
     override val defaultLanguage: Locale = RebarConfig.DEFAULT_LANGUAGE
+}
+
+/**
+ * Paper may expose an API version with an explicit patch component (for example
+ * "26.2.0") while Bukkit.getMinecraftVersion() reports the same release as
+ * "26.2". Compare the numeric components after removing trailing zero patch
+ * components instead of comparing the raw strings.
+ */
+private fun minecraftVersionsMatch(actual: String, expected: String): Boolean {
+    val actualComponents = normalizeMinecraftVersion(actual) ?: return false
+    val expectedComponents = normalizeMinecraftVersion(expected) ?: return false
+    return actualComponents == expectedComponents
+}
+
+private fun normalizeMinecraftVersion(version: String): List<Int>? {
+    val components = version.split('.').map {
+        it.toIntOrNull() ?: return null
+    }.toMutableList()
+
+    while (components.size > 2 && components.last() == 0) {
+        components.removeAt(components.lastIndex)
+    }
+
+    return components
 }
 
 private fun addDefaultPermission(permission: String) {


### PR DESCRIPTION
Improves Rebar's behavior when startup fails before all plugin services have been initialized.

I encountered this while testing version compatibility failures. onDisable() can still run after an unsuccessful onEnable(), which means accessing lazy services during shutdown can initialize them after the plugin is already being disabled.

This change:

avoids initializing metrics during a failed shutdown
only cancels the coroutine scope if it was initialized
uses Bukkit's Minecraft version for compatibility detection
normalizes equivalent version forms such as 26.2 and 26.2.0

The normal successful startup/shutdown path remains unchanged.