### PR TITLE
Restore recipes after resource reload

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/addon/RebarAddon.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/addon/RebarAddon.kt
@@ -4,7 +4,9 @@ import io.github.pylonmc.rebar.Rebar
 import io.github.pylonmc.rebar.block.BlockStorage
 import io.github.pylonmc.rebar.entity.EntityStorage
 import io.github.pylonmc.rebar.i18n.RebarTranslator.Companion.translator
+import io.github.pylonmc.rebar.recipe.RecipeType
 import io.github.pylonmc.rebar.registry.RebarRegistry
+import io.papermc.paper.event.server.ServerResourcesReloadedEvent
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TranslatableComponent
 import net.kyori.adventure.text.format.NamedTextColor
@@ -91,6 +93,16 @@ interface RebarAddon : Keyed {
 
     @ApiStatus.Internal
     companion object : Listener {
+        @EventHandler
+        private fun onServerResourcesReloaded(event: ServerResourcesReloadedEvent) {
+            val restored = RecipeType.restoreDynamicRecipesAfterResourceReload()
+            if (restored > 0) {
+                Rebar.logger.info(
+                    "Restored $restored Rebar/Pylon recipe registrations after server resource reload (${event.cause})."
+                )
+            }
+        }
+
         @EventHandler
         private fun onPluginDisable(event: PluginDisableEvent) {
             val plugin = event.plugin

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeType.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/recipe/RecipeType.kt
@@ -1,5 +1,6 @@
 package io.github.pylonmc.rebar.recipe
 
+import io.github.pylonmc.rebar.nms.NmsAccessor
 import io.github.pylonmc.rebar.recipe.vanilla.*
 import io.github.pylonmc.rebar.registry.RebarRegistry
 import org.bukkit.Bukkit
@@ -152,6 +153,57 @@ open class RecipeType<T : RebarRecipe>(private val key: NamespacedKey) : Keyed, 
         fun isDummyRecipe(key: NamespacedKey) = DUMMY_CRAFTING.hasRecipe(key)
                 || DUMMY_COOKING.hasRecipe(key)
                 || DUMMY_SMITHING.hasRecipe(key)
+
+        /**
+         * Paper rebuilds the live recipe registry when server resources/datapacks are reloaded.
+         * Rebar's configurable recipes are registered dynamically after that registry is built, so
+         * a later reload would otherwise remove every Rebar/Pylon Bukkit recipe while leaving the
+         * in-memory Rebar recipe objects intact.
+         *
+         * Re-register only recipes that are missing from Paper's live registry. Vanilla recipes
+         * captured during startup are deliberately skipped, while Rebar's dummy recipes are safe
+         * to restore because they are only created for dynamically registered Rebar recipes.
+         *
+         * @return number of Bukkit recipes queued for restoration
+         */
+        @JvmSynthetic
+        internal fun restoreDynamicRecipesAfterResourceReload(): Int {
+            var restored = 0
+
+            fun queueIfMissing(recipe: BukkitRebarRecipe) {
+                if (!NmsAccessor.instance.hasRecipe(recipe.key)) {
+                    NmsAccessor.queueRegisterRecipe(recipe.bukkitRecipe)
+                    restored++
+                }
+            }
+
+            fun queueDynamic(recipes: Collection<out BukkitRebarRecipe>) {
+                for (recipe in recipes) {
+                    if (recipe.key !in VanillaRecipeType.nonRebarRecipes) {
+                        queueIfMissing(recipe)
+                    }
+                }
+            }
+
+            queueDynamic(VANILLA_BLASTING.recipes)
+            queueDynamic(VANILLA_CAMPFIRE.recipes)
+            queueDynamic(VANILLA_SMELTING.recipes)
+            queueDynamic(VANILLA_SHAPED.recipes)
+            queueDynamic(VANILLA_SHAPELESS.recipes)
+            queueDynamic(VANILLA_SMITHING_TRANSFORM.recipes)
+            queueDynamic(VANILLA_SMITHING_TRIM.recipes)
+            queueDynamic(VANILLA_SMOKING.recipes)
+
+            for (recipe in DUMMY_CRAFTING.recipes) queueIfMissing(recipe)
+            for (recipe in DUMMY_COOKING.recipes) queueIfMissing(recipe)
+            for (recipe in DUMMY_SMITHING.recipes) queueIfMissing(recipe)
+
+            if (restored > 0) {
+                NmsAccessor.processRecipeQueue()
+            }
+
+            return restored
+        }
 
         @JvmSynthetic
         internal fun addVanillaRecipes() {


### PR DESCRIPTION
Fixes Rebar/Pylon recipes disappearing after Paper reloads server resources.

I ran into this while testing crafting on a live Paper 26.2 server. Paper rebuilds its recipe registry during a resource/datapack reload, which can remove recipes that Rebar registered dynamically after startup.

This listens for ServerResourcesReloadedEvent and re-registers Rebar recipes that are missing from the live registry.

Vanilla recipes that Rebar discovered during startup are left alone.