### PR TITLE
fix(i18n): fall back to default language for missing keys

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/addon/RebarAddon.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/addon/RebarAddon.kt
@@ -82,7 +82,7 @@ interface RebarAddon : Keyed {
         RebarRegistry.ADDONS.register(this)
         if (!suppressAddonNameWarning) {
             for (locale in translator.languages) {
-                if (!translator.canTranslate("${key.namespace}.addon", locale)) {
+                if (!translator.canTranslateExact("${key.namespace}.addon", locale)) {
                     Rebar.logger.warning("${key.namespace} is missing the 'addon' translation key for ${locale.displayName}")
                 }
             }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/fluid/RebarFluid.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/fluid/RebarFluid.kt
@@ -64,7 +64,7 @@ open class RebarFluid(
         if (key !in nameWarningsSuppressed) {
             for (locale in addon.translator.languages) {
                 val translationKey = "${key.namespace}.fluid.${key.key}"
-                if (!addon.translator.canTranslate(translationKey, locale)) {
+                if (!addon.translator.canTranslateExact(translationKey, locale)) {
                     Rebar.logger.warning("${key.namespace} is missing a translation key for fluid ${key.key} (locale: ${locale.displayName} | expected translation key: $translationKey)")
                 }
             }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
@@ -137,8 +137,10 @@ class RebarTranslator private constructor(private val addon: RebarAddon) : Trans
             if (parts.size < 2) return null
             val (addon, key) = parts
             if (addon != addonNamespace) return null
-            val translations = findTranslations(locale) ?: findTranslations(this.addon.defaultLanguage) ?: return null
-            val translation = translations.get(key, ConfigAdapter.STRING) ?: return null
+            val translations = findTranslations(locale)
+            val translation = translations?.get(key, ConfigAdapter.STRING)
+                ?: findTranslations(this.addon.defaultLanguage)?.get(key, ConfigAdapter.STRING)
+                ?: return null
             customMiniMessage.deserialize(translation)
         }
     }

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/i18n/RebarTranslator.kt
@@ -28,6 +28,7 @@ import net.kyori.adventure.text.format.Style
 import net.kyori.adventure.translation.GlobalTranslator
 import net.kyori.adventure.translation.Translator
 import org.apache.commons.lang3.LocaleUtils
+import org.jetbrains.annotations.ApiStatus
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
@@ -105,6 +106,18 @@ class RebarTranslator private constructor(private val addon: RebarAddon) : Trans
         return getRawTranslation(key, locale) != null
     }
 
+    /**
+     * Whether [key] is present in the language file matching [locale], without
+     * falling back to the addon's default language. Used by missing-translation
+     * warnings; player-facing lookups should use [canTranslate] instead.
+     */
+    @ApiStatus.Internal
+    fun canTranslateExact(key: String, locale: Locale): Boolean {
+        val parts = key.split('.', limit = 2)
+        if (parts.size < 2 || parts[0] != addonNamespace) return false
+        return findTranslations(locale)?.get(parts[1], ConfigAdapter.STRING) != null
+    }
+
     override fun translate(component: TranslatableComponent, locale: Locale): Component? {
         var translation = getRawTranslation(component.key(), locale) ?: return null
         for (arg in component.arguments()) {
@@ -137,8 +150,7 @@ class RebarTranslator private constructor(private val addon: RebarAddon) : Trans
             if (parts.size < 2) return null
             val (addon, key) = parts
             if (addon != addonNamespace) return null
-            val translations = findTranslations(locale)
-            val translation = translations?.get(key, ConfigAdapter.STRING)
+            val translation = findTranslations(locale)?.get(key, ConfigAdapter.STRING)
                 ?: findTranslations(this.addon.defaultLanguage)?.get(key, ConfigAdapter.STRING)
                 ?: return null
             customMiniMessage.deserialize(translation)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/item/RebarItem.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/item/RebarItem.kt
@@ -116,7 +116,7 @@ open class RebarItem(val stack: ItemStack) : Keyed {
             if (isNameValid) {
                 val translator = schema.addon.translator
                 for (locale in schema.addon.translator.languages) {
-                    if (!translator.canTranslate(name!!.key(), locale)) {
+                    if (!translator.canTranslateExact(name!!.key(), locale)) {
                         Rebar.logger.warning(
                             "${schema.key.namespace} is missing a name translation key for item ${schema.key} (locale: ${locale.displayName} | expected translation key: ${
                                 ItemStackBuilder.nameKey(

--- a/test/src/main/java/io/github/pylonmc/rebar/test/RebarTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/RebarTest.java
@@ -14,6 +14,7 @@ import io.github.pylonmc.rebar.test.test.entity.EntityStorageChunkReloadTest;
 import io.github.pylonmc.rebar.test.test.entity.EntityStorageSimpleTest;
 import io.github.pylonmc.rebar.test.test.entity.EntityStorageUnregisteredEntityTest;
 import io.github.pylonmc.rebar.test.test.fluid.*;
+import io.github.pylonmc.rebar.test.test.i18n.TranslationFallbackTest;
 import io.github.pylonmc.rebar.test.test.item.RebarItemStackInterfaceTest;
 import io.github.pylonmc.rebar.test.test.misc.GametestTest;
 import io.github.pylonmc.rebar.test.test.recipe.CraftingTest;
@@ -61,6 +62,7 @@ public class RebarTest extends JavaPlugin implements RebarAddon {
         tests.add(new RebarItemStackInterfaceTest());
 
         tests.add(new GametestTest());
+        tests.add(new TranslationFallbackTest());
 
         tests.add(new SerializerTestBlockPosition());
         tests.add(new SerializerTestBlockPositionNoWorld());
@@ -210,6 +212,6 @@ public class RebarTest extends JavaPlugin implements RebarAddon {
 
     @Override
     public @NotNull Locale getDefaultLanguage() {
-        return Locale.of("none");
+        return Locale.ENGLISH;
     }
 }

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/i18n/TranslationFallbackTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/i18n/TranslationFallbackTest.java
@@ -44,6 +44,11 @@ public class TranslationFallbackTest extends SyncTest {
         assertThat(translator.canTranslate(MISSING_EVERYWHERE, Locale.SIMPLIFIED_CHINESE)).isFalse();
         assertThat(translator.translate(Component.translatable(MISSING_EVERYWHERE), Locale.SIMPLIFIED_CHINESE)).isNull();
 
+        // Exact lookups bypass the fallback (used by missing-translation warnings)
+        assertThat(translator.canTranslateExact(PRESENT_BOTH, Locale.SIMPLIFIED_CHINESE)).isTrue();
+        assertThat(translator.canTranslateExact(DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isFalse();
+        assertThat(translator.canTranslateExact(DEFAULT_ONLY, Locale.ENGLISH)).isTrue();
+
         // Repeated lookups stay consistent
         assertThat(render(translator, DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isEqualTo("English fallback value");
 

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/i18n/TranslationFallbackTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/i18n/TranslationFallbackTest.java
@@ -1,0 +1,61 @@
+package io.github.pylonmc.rebar.test.test.i18n;
+
+import io.github.pylonmc.rebar.i18n.RebarTranslator;
+import io.github.pylonmc.rebar.test.RebarTest;
+import io.github.pylonmc.rebar.test.base.SyncTest;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests per-key fallback to the addon's default language (see pylonmc/rebar#591).
+ *
+ * The test addon ships an incomplete zh_cn.yml: test.translation.default_only only
+ * exists in en.yml, so the zh_CN locale should resolve it from the default language.
+ */
+public class TranslationFallbackTest extends SyncTest {
+
+    private static final String PRESENT_BOTH = "rebartest.test.translation.present_both";
+    private static final String DEFAULT_ONLY = "rebartest.test.translation.default_only";
+    private static final String MISSING_EVERYWHERE = "rebartest.test.translation.missing_everywhere";
+
+    @Override
+    protected void test() {
+        RebarTranslator translator = RebarTranslator.getTranslatorForAddon(RebarTest.instance());
+
+        // Key present in the matched locale file uses the locale value
+        assertThat(render(translator, PRESENT_BOTH, Locale.SIMPLIFIED_CHINESE)).isEqualTo("中文值");
+
+        // Key missing from the matched locale file falls back to the default language
+        assertThat(render(translator, DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isEqualTo("English fallback value");
+        assertThat(translator.canTranslate(DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isTrue();
+
+        // Locale with no file at all keeps the file-level fallback behavior
+        assertThat(render(translator, DEFAULT_ONLY, Locale.FRENCH)).isEqualTo("English fallback value");
+
+        // Default language itself is unaffected
+        assertThat(render(translator, PRESENT_BOTH, Locale.ENGLISH)).isEqualTo("English value");
+
+        // Key missing everywhere still reports as untranslatable
+        assertThat(translator.canTranslate(MISSING_EVERYWHERE, Locale.SIMPLIFIED_CHINESE)).isFalse();
+        assertThat(translator.translate(Component.translatable(MISSING_EVERYWHERE), Locale.SIMPLIFIED_CHINESE)).isNull();
+
+        // Repeated lookups stay consistent
+        assertThat(render(translator, DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isEqualTo("English fallback value");
+
+        // Results stay consistent across reloads
+        translator.reload();
+        assertThat(render(translator, DEFAULT_ONLY, Locale.SIMPLIFIED_CHINESE)).isEqualTo("English fallback value");
+        assertThat(render(translator, PRESENT_BOTH, Locale.SIMPLIFIED_CHINESE)).isEqualTo("中文值");
+    }
+
+    private static String render(RebarTranslator translator, String key, Locale locale) {
+        @Nullable Component component = translator.translate(Component.translatable(key), locale);
+        assertThat(component).isNotNull();
+        return PlainTextComponentSerializer.plainText().serialize(component);
+    }
+}

--- a/test/src/main/resources/lang/en.yml
+++ b/test/src/main/resources/lang/en.yml
@@ -1,0 +1,16 @@
+addon: "RebarTest"
+
+item:
+  simple_block:
+    name: "Simple Block"
+  simple_multiblock:
+    name: "Simple Multiblock"
+
+fluid:
+  water: "Water"
+  lava: "Lava"
+
+test:
+  translation:
+    present_both: "English value"
+    default_only: "English fallback value"

--- a/test/src/main/resources/lang/zh_cn.yml
+++ b/test/src/main/resources/lang/zh_cn.yml
@@ -1,0 +1,7 @@
+# Intentionally incomplete: test.translation.default_only and the item/fluid names
+# are only present in en.yml to exercise per-key fallback (see pylonmc/rebar#591).
+addon: "RebarTest"
+
+test:
+  translation:
+    present_both: "中文值"


### PR DESCRIPTION
Closes #591

Missing a translation key no longer shows the full key, it fallbacks to the default language instead. 
The console warning for the missing key is kept.

Existing entry:
<img width="420" height="255" alt="Image_2026-08-19_00-36-50_hzfbivnq 5xt" src="https://github.com/user-attachments/assets/ac6e6b8d-9ca4-4291-a847-4cedeef05973" />

New entry added, without Chinese translation (current behavior):
<img width="561" height="258" alt="image" src="https://github.com/user-attachments/assets/56152be0-3cda-43a3-bb19-d0fb112c0c69" />

New behavior, fallback to English:
<img width="342" height="253" alt="Image_2026-08-19_00-38-06_qcuj2k4p cmx" src="https://github.com/user-attachments/assets/1860ec03-5ff0-40b8-8b80-bd76fc263e71" />
