### PR TITLE
Fix StructureGrowRebarBlockHandler

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/StructureGrowRebarBlockHandler.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/StructureGrowRebarBlockHandler.kt
@@ -24,8 +24,6 @@ interface StructureGrowRebarBlockHandler {
                 } catch (e: Exception) {
                     BlockListener.logEventHandleErr(event, e, rebarBlock)
                 }
-            } else if (priority == EventPriority.LOWEST) {
-                event.isCancelled = true
             }
         }
     }


### PR DESCRIPTION
Updated StructureGrowRebarBlockHandler to fix any StructureGrowEvent whose source block isn't a Rebar block getting cancelled. This fix allows sapling blocks to grow again where previously they wouldn't.

This pull request made use of AI to find the problem and offer potential solutions. I've looked over the changes myself and tested them in-game.