### PR TITLE
Fix merchant cost translation mutation

### DIFF
--- a/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
+++ b/nms/src/main/kotlin/io/github/pylonmc/rebar/nms/packet/PlayerPacketHandler.kt
@@ -317,7 +317,7 @@ class PlayerPacketHandler(private val player: ServerPlayer, val handler: PlayerT
     }
 
     private fun translate(itemCost: ItemCost): ItemCost {
-        val costStack = translate(itemCost.itemStack)
+        val costStack = translate(itemCost.itemStack.copy())
         val costPredicate = DataComponentExactPredicate.allOf(PatchedDataComponentMap.fromPatch(DataComponentMap.EMPTY, costStack.componentsPatch))
         return ItemCost(costStack.typeHolder(), costStack.count, costPredicate, costStack)
     }


### PR DESCRIPTION
While testing villager trading on Paper 26.2, I noticed Rebar is still translating the ItemCost stack directly when rebuilding merchant offers.

Since that stack can still be tied to the original offer, translating it in place can modify the server-side trade.

This just makes a copy of the cost stack before translation so the client gets the translated version without touching the original villager trade.

Small change, but it should prevent trade desync / interaction issues especially with other plugins like Villager Trade or Villager Market