### PR TITLE
Make clazz the second parameter of BlockStorage.getAs

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
@@ -129,7 +129,7 @@ object BlockStorage : Listener {
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
     @JvmStatic
-    fun <T> getAs(clazz: Class<T>, blockPosition: BlockPosition?): T? {
+    fun <T> getAs(blockPosition: BlockPosition?, clazz: Class<T>): T? {
         val block = get(blockPosition) ?: return null
         if (!clazz.isInstance(block)) {
             return null
@@ -144,7 +144,7 @@ object BlockStorage : Listener {
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
     @JvmStatic
-    fun <T> getAs(clazz: Class<T>, block: Block?): T? = block?.let { getAs(clazz, it.position) }
+    fun <T> getAs(block: Block?, clazz: Class<T>): T? = block?.let { getAs(it.position, clazz) }
 
     /**
      * Returns the Rebar block (of type [T]) at the given [location], or null if the block
@@ -153,7 +153,7 @@ object BlockStorage : Listener {
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
     @JvmStatic
-    fun <T> getAs(clazz: Class<T>, location: Location?): T? = location?.let { getAs(clazz, BlockPosition(it)) }
+    fun <T> getAs(location: Location?, clazz: Class<T>): T? = location?.let { getAs(BlockPosition(it), clazz) }
 
     /**
      * Gets the Rebar block (of type [T]) at the given [blockPosition].
@@ -163,7 +163,7 @@ object BlockStorage : Listener {
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
     inline fun <reified T> getAs(blockPosition: BlockPosition?): T? =
-        getAs(T::class.java, blockPosition)
+        getAs(blockPosition, T::class.java)
 
     /**
      * Returns the Rebar block (of type [T]) at the given [block].
@@ -172,7 +172,7 @@ object BlockStorage : Listener {
      *
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
-    inline fun <reified T> getAs(block: Block?): T? = getAs(T::class.java, block)
+    inline fun <reified T> getAs(block: Block?): T? = getAs(block, T::class.java)
 
     /**
      * Returns the Rebar block (of type [T]) at the given [location].
@@ -181,7 +181,7 @@ object BlockStorage : Listener {
      *
      * @throws IllegalArgumentException if the chunk containing the block is not loaded
      */
-    inline fun <reified T> getAs(location: Location?): T? = getAs(T::class.java, location)
+    inline fun <reified T> getAs(location: Location?): T? = getAs(location, T::class.java)
 
     /**
      * Returns all the Rebar blocks in the chunk at [chunkPosition].

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
@@ -137,6 +137,13 @@ object BlockStorage : Listener {
         return clazz.cast(block)
     }
 
+    @Deprecated(
+        message = "Use getAs(blockPosition, clazz) instead",
+        replaceWith = ReplaceWith("getAs(blockPosition, clazz)")
+    )
+    @JvmStatic
+    fun <T> getAs(clazz: Class<T>, blockPosition: BlockPosition?): T? = getAs(blockPosition, clazz)
+
     /**
      * Returns the Rebar block (of type [T]) at the given [block], or null if the block
      * does not exist or is not of the expected class.
@@ -146,6 +153,13 @@ object BlockStorage : Listener {
     @JvmStatic
     fun <T> getAs(block: Block?, clazz: Class<T>): T? = block?.let { getAs(it.position, clazz) }
 
+    @Deprecated(
+        message = "Use getAs(block, clazz) instead",
+        replaceWith = ReplaceWith("getAs(block, clazz)")
+    )
+    @JvmStatic
+    fun <T> getAs(clazz: Class<T>, block: Block?): T? = getAs(block, clazz)
+
     /**
      * Returns the Rebar block (of type [T]) at the given [location], or null if the block
      * does not exist or is not of the expected class.
@@ -154,6 +168,13 @@ object BlockStorage : Listener {
      */
     @JvmStatic
     fun <T> getAs(location: Location?, clazz: Class<T>): T? = location?.let { getAs(BlockPosition(it), clazz) }
+
+    @Deprecated(
+        message = "Use getAs(location, clazz) instead",
+        replaceWith = ReplaceWith("getAs(location, clazz)")
+    )
+    @JvmStatic
+    fun <T> getAs(clazz: Class<T>, location: Location?): T? = getAs(location, clazz)
 
     /**
      * Gets the Rebar block (of type [T]) at the given [blockPosition].

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/BlockStorage.kt
@@ -137,13 +137,6 @@ object BlockStorage : Listener {
         return clazz.cast(block)
     }
 
-    @Deprecated(
-        message = "Use getAs(blockPosition, clazz) instead",
-        replaceWith = ReplaceWith("getAs(blockPosition, clazz)")
-    )
-    @JvmStatic
-    fun <T> getAs(clazz: Class<T>, blockPosition: BlockPosition?): T? = getAs(blockPosition, clazz)
-
     /**
      * Returns the Rebar block (of type [T]) at the given [block], or null if the block
      * does not exist or is not of the expected class.
@@ -153,13 +146,6 @@ object BlockStorage : Listener {
     @JvmStatic
     fun <T> getAs(block: Block?, clazz: Class<T>): T? = block?.let { getAs(it.position, clazz) }
 
-    @Deprecated(
-        message = "Use getAs(block, clazz) instead",
-        replaceWith = ReplaceWith("getAs(block, clazz)")
-    )
-    @JvmStatic
-    fun <T> getAs(clazz: Class<T>, block: Block?): T? = getAs(block, clazz)
-
     /**
      * Returns the Rebar block (of type [T]) at the given [location], or null if the block
      * does not exist or is not of the expected class.
@@ -168,13 +154,6 @@ object BlockStorage : Listener {
      */
     @JvmStatic
     fun <T> getAs(location: Location?, clazz: Class<T>): T? = location?.let { getAs(BlockPosition(it), clazz) }
-
-    @Deprecated(
-        message = "Use getAs(location, clazz) instead",
-        replaceWith = ReplaceWith("getAs(location, clazz)")
-    )
-    @JvmStatic
-    fun <T> getAs(clazz: Class<T>, location: Location?): T? = getAs(location, clazz)
 
     /**
      * Gets the Rebar block (of type [T]) at the given [blockPosition].

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/GuiRebarBlock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/GuiRebarBlock.kt
@@ -101,7 +101,7 @@ interface GuiRebarBlock : NoVanillaInventoryRebarBlock {
 
         @EventHandler(priority = EventPriority.HIGHEST)
         private fun onInteract(event: PlayerInteractEvent) {
-            val guiBlock = BlockStorage.getAs(GuiRebarBlock::class.java, event.clickedBlock ?: return) ?: return
+            val guiBlock = BlockStorage.getAs(event.clickedBlock ?: return, GuiRebarBlock::class.java) ?: return
 
             if (!event.action.isRightClick
                 || (event.player.isSneaking && event.isBlockInHand)

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/block/interfaces/SimpleRebarMultiblock.kt
@@ -247,7 +247,7 @@ interface SimpleRebarMultiblock : RebarMultiblock, GhostBlockHolderRebarBlock, E
         BlockStorage.get(getMultiblockBlock(position))
 
     fun <T> getMultiblockComponent(clazz: Class<T>, position: Vector3i) =
-        BlockStorage.getAs(clazz, getMultiblockBlock(position))
+        BlockStorage.getAs(getMultiblockBlock(position), clazz)
 
     fun getMultiblockComponentOrThrow(position: Vector3i) =
         getMultiblockComponent(position) ?: throw IllegalStateException("There is no Rebar block at $position")

--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionDisplay.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/content/fluid/FluidIntersectionDisplay.kt
@@ -71,7 +71,7 @@ class FluidIntersectionDisplay : RebarEntity<ItemDisplay>, RemoveRebarEntityHand
     fun updateItemDisplay() {
         if (connectedPipeDisplays.isEmpty()) return
 
-        val marker = BlockStorage.getAs(FluidIntersectionMarker::class.java, entity.location.block) ?: return
+        val marker = BlockStorage.getAs(entity.location.block, FluidIntersectionMarker::class.java) ?: return
         val modelData = CustomModelData.customModelData().addString("fluid_point_intersection:${marker.pipe.key}")
 
         val from = this.entity.location

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageAddTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageAddTest.java
@@ -24,7 +24,7 @@ public class BlockStorageAddTest extends GameTest {
                             .isNotNull()
                             .isInstanceOf(RebarBlock.class);
 
-                    assertThat(BlockStorage.getAs(RebarBlock.class, test.location()))
+                    assertThat(BlockStorage.getAs(test.location(), RebarBlock.class))
                             .isNotNull();
 
                     BlockStorage.breakBlock(test.location());

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageChunkReloadTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/BlockStorageChunkReloadTest.java
@@ -53,7 +53,7 @@ public class BlockStorageChunkReloadTest extends AsyncTest {
                         .extracting(RebarBlock::getSchema)
                         .isInstanceOf(RebarBlockSchema.class);
 
-                assertThat(BlockStorage.getAs(BlockWithField.class, block))
+                assertThat(BlockStorage.getAs(block, BlockWithField.class))
                         .isNotNull()
                         .extracting(BlockWithField::getProgress)
                         .isEqualTo(130);

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/block/TickingBlockTest.java
@@ -16,7 +16,7 @@ public class TickingBlockTest extends GameTest {
                 .setUp((test) -> {
                     BlockStorage.placeBlock(test.location(), TickingBlock.KEY);
 
-                    test.succeedWhen(() -> BlockStorage.getAs(TickingBlock.class, test.location()).ticks >= 5);
+                    test.succeedWhen(() -> BlockStorage.getAs(test.location(), TickingBlock.class).ticks >= 5);
                 })
                 .cleanup(test -> BlockStorage.breakBlock(test.location()))
                 .build());

--- a/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPartialReloadTest.java
+++ b/test/src/main/java/io/github/pylonmc/rebar/test/test/fluid/FluidPartialReloadTest.java
@@ -53,7 +53,7 @@ public class FluidPartialReloadTest extends AsyncTest {
 
         // When the chunk is reloaded, all should have the same segment again
         TestUtil.loadChunk(connectorChunk).join();
-        FluidConnector reloadedConnector = BlockStorage.getAs(FluidConnector.class, connectorBlock);
+        FluidConnector reloadedConnector = BlockStorage.getAs(connectorBlock, FluidConnector.class);
         assertThat(consumer.getPoint().getSegment())
                 .isEqualTo(reloadedConnector.getPoint().getSegment())
                 .isEqualTo(producer.getPoint().getSegment());


### PR DESCRIPTION
Fixes #904

Updates the BlockStorage.getAs method signatures so the clazz parameter is the second argument for consistency with the rest of the codebase. Updates affected Kotlin and Java call sites while preserving existing behavior.

Validation:

* :rebar:compileKotlin
* :test:compileJava
* :rebar:classes :test:classes

All completed successfully.