### PR TITLE
fix: yawToCardinalDirection returns degrees instead of radians

### DIFF
--- a/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/transform/TransformUtil.kt
+++ b/rebar/src/main/kotlin/io/github/pylonmc/rebar/entity/display/transform/TransformUtil.kt
@@ -16,7 +16,7 @@ object TransformUtil {
 
     @JvmStatic
     fun yawToCardinalDirection(yaw: Double): Double
-        = -(yaw / 90.0F).roundToInt() * (Math.PI / 2)
+        = -(yaw / 90.0F).roundToInt() * 90.0
     @JvmStatic
     fun yawToCardinalDirection(yaw: Float): Float
         = yawToCardinalDirection(yaw.toDouble()).toFloat()


### PR DESCRIPTION
## Issue

Fixes #465

The `yawToCardinalDirection` method accepted yaw input in degrees but returned the snapped cardinal direction in radians.

## Summary

Changed the return unit from radians to degrees.

## Testing

- Ran `./gradlew :rebar:shadowJar -Pversion=local` successfully.
- Searched for usages of `yawToCardinalDirection` and found zero callers in the codebase.